### PR TITLE
Separator bug fix to read all datasets

### DIFF
--- a/caserec/recommenders/item_recommendation/base_item_recommendation.py
+++ b/caserec/recommenders/item_recommendation/base_item_recommendation.py
@@ -83,7 +83,7 @@ class BaseItemRecommendation(object):
         self.train_set = ReadFile(self.train_file, sep=self.sep, as_binary=self.as_binary).read()
 
         if self.test_file is not None:
-            self.test_set = ReadFile(self.test_file).read()
+            self.test_set = ReadFile(self.test_file, sep=self.sep).read()
             self.users = sorted(set(list(self.train_set['users']) + list(self.test_set['users'])))
             self.items = sorted(set(list(self.train_set['items']) + list(self.test_set['items'])))
         else:


### PR DESCRIPTION
In the base_item_recommendation.py when the dataset is not separated with \t, the default separator, an error appears in the ReadFile method. I added only the parameter sep to the ReadFile method to fix the bug